### PR TITLE
Fix PostgreSQL support

### DIFF
--- a/Source/ConnectionViewModel.cs
+++ b/Source/ConnectionViewModel.cs
@@ -22,7 +22,7 @@ namespace LinqToDB.LINQPad
 				new ProviderInfo { Name = ProviderName.MySql,         Description = "MySql", },
 				//new ProviderInfo { Name = ProviderName.OracleNative,  Description = "Oracle ODP.NET", },
 				new ProviderInfo { Name = ProviderName.OracleManaged, Description = "Oracle Managed Driver", },
-				new ProviderInfo { Name = ProviderName.PostgreSQL,    Description = "PostgreSQL", },
+				new ProviderInfo { Name = ProviderName.PostgreSQL92,  Description = "PostgreSQL", },
 				new ProviderInfo { Name = ProviderName.SqlCe,         Description = "Microsoft SQL Server Compact", },
 				new ProviderInfo { Name = ProviderName.SQLite,        Description = "SQLite", },
 				new ProviderInfo { Name = ProviderName.Sybase,        Description = "SAP Sybase ASE", },

--- a/Source/SchemaAndCodeGenerator.cs
+++ b/Source/SchemaAndCodeGenerator.cs
@@ -119,9 +119,9 @@ namespace LinqToDB.LINQPad
 					References.Add(typeof(Oracle.ManagedDataAccess.Client.OracleConnection).Assembly.Location);
 					break;
 
-				case LinqToDB.ProviderName.PostgreSQL :
-                case LinqToDB.ProviderName.PostgreSQL92 :
-                case LinqToDB.ProviderName.PostgreSQL93 :
+				case LinqToDB.ProviderName.PostgreSQL   :
+				case LinqToDB.ProviderName.PostgreSQL92 :
+				case LinqToDB.ProviderName.PostgreSQL93 :
 					References.Add(typeof(Npgsql.NpgsqlConnection).Assembly.Location);
 					break;
 

--- a/Source/SchemaAndCodeGenerator.cs
+++ b/Source/SchemaAndCodeGenerator.cs
@@ -120,6 +120,8 @@ namespace LinqToDB.LINQPad
 					break;
 
 				case LinqToDB.ProviderName.PostgreSQL :
+                case LinqToDB.ProviderName.PostgreSQL92 :
+                case LinqToDB.ProviderName.PostgreSQL93 :
 					References.Add(typeof(Npgsql.NpgsqlConnection).Assembly.Location);
 					break;
 


### PR DESCRIPTION
LinqToDB does not provide a provider with the name "PostgreSQL", so adding a Postgres connection was failing. LinqToDB provides two versions of Postgres support, with the base PostgreSQL enum case falling back to 9.2.

This PR explicitly uses PostgreSQL92 so that the LINQPad driver can actually connect.