### PR TITLE
Release 2.7.0

### DIFF
--- a/Source/linq2db.LINQPad.csproj
+++ b/Source/linq2db.LINQPad.csproj
@@ -17,17 +17,17 @@
 
 	<ItemGroup>
 	  <PackageReference Include="CodeJam" Version="2.1.1" />
-	  <PackageReference Include="Extended.Wpf.Toolkit" Version="3.4.0" />
-	  <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="6.4.0" />
-	  <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
+	  <PackageReference Include="Extended.Wpf.Toolkit" Version="3.5.0" />
+	  <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="6.6.0" />
+	  <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
 	  <PackageReference Include="linq2db" Version="2.6.0" />
-	  <PackageReference Include="linq2db4iSeries" Version="2.6.0" />
+	  <PackageReference Include="linq2db4iSeries" Version="2.6.1" />
 	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" />
 	  <PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
-	  <PackageReference Include="MySql.Data" Version="8.0.13" />
-	  <PackageReference Include="Npgsql" Version="4.0.4" />
-	  <PackageReference Include="Oracle.ManagedDataAccess" Version="18.3.0" />
-	  <PackageReference Include="System.Data.SQLite.Core" Version="1.0.109.2" />
+	  <PackageReference Include="MySql.Data" Version="8.0.15" />
+	  <PackageReference Include="Npgsql" Version="4.0.6" />
+	  <PackageReference Include="Oracle.ManagedDataAccess" Version="18.6.0" />
+	  <PackageReference Include="System.Data.SQLite.Core" Version="1.0.110" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/linq2db.LINQPad.csproj
+++ b/Source/linq2db.LINQPad.csproj
@@ -20,11 +20,11 @@
 	  <PackageReference Include="Extended.Wpf.Toolkit" Version="3.5.0" />
 	  <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="6.6.0" />
 	  <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
-	  <PackageReference Include="linq2db" Version="2.6.0" />
-	  <PackageReference Include="linq2db4iSeries" Version="2.6.1" />
+	  <PackageReference Include="linq2db" Version="2.7.0" />
+	  <PackageReference Include="linq2db4iSeries" Version="2.7.0" />
 	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" />
 	  <PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
-	  <PackageReference Include="MySql.Data" Version="8.0.15" />
+	  <PackageReference Include="MySql.Data" Version="8.0.16" />
 	  <PackageReference Include="Npgsql" Version="4.0.6" />
 	  <PackageReference Include="Oracle.ManagedDataAccess" Version="18.6.0" />
 	  <PackageReference Include="System.Data.SQLite.Core" Version="1.0.110" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,12 @@
-version: 2.6.0.{build}
+version: 2.7.0.{build}
 os: Visual Studio 2017
 configuration: Release
 assembly_info:
   patch: true
   file: '**\AssemblyInfo.*'
-  assembly_version: '2.6.0'
-  assembly_file_version: '2.6.0'
-  assembly_informational_version: '2.6.0'
+  assembly_version: '2.7.0'
+  assembly_file_version: '2.7.0'
+  assembly_informational_version: '2.7.0'
 before_build:
 - cmd: nuget restore
 build:


### PR DESCRIPTION
Update linq2db to v2.7.0

This release will also fix support of  MySQL databases with full-text search indexes.

- [x] updated 3rd party providers to recent versions
- [x] update DB2iSeries provider
- [x] update linq2db to 2.7.0
- [x] local testing