### PR TITLE
Release 2.9.3

### DIFF
--- a/Source/LinqToDBDriver.cs
+++ b/Source/LinqToDBDriver.cs
@@ -31,6 +31,7 @@ namespace LinqToDB.LINQPad
 		static LinqToDBDriver()
 		{
 			DriverHelper.ConfigureRedirects();
+			DriverHelper.SapHanaSPS04Fixes();
 		}
 
 		public override string GetConnectionDescription(IConnectionInfo cxInfo)

--- a/Source/linq2db.LINQPad.csproj
+++ b/Source/linq2db.LINQPad.csproj
@@ -6,7 +6,7 @@
 		<Company>linq2db</Company>
 		<Product>linq2db.LINQPad</Product>
 		<AssemblyTitle>$(Product)</AssemblyTitle>
-		<Version>2.9.1</Version>
+		<Version>2.9.3</Version>
 		<AssemblyVersion>$(Version)</AssemblyVersion>
 		<FileVersion>$(Version)</FileVersion>
 		<Copyright>Copyright © 2018 Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</Copyright>
@@ -20,14 +20,14 @@
 	  <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" />
 	  <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.1.1" />
 	  <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-	  <PackageReference Include="linq2db" Version="2.9.1" />
+	  <PackageReference Include="linq2db" Version="2.9.3" />
 	  <PackageReference Include="linq2db4iSeries" Version="2.9.0" />
 	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" />
 	  <PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
-	  <PackageReference Include="MySql.Data" Version="8.0.17" />
+	  <PackageReference Include="MySql.Data" Version="8.0.18" />
 	  <PackageReference Include="Npgsql" Version="4.0.10" />
-	  <PackageReference Include="Oracle.ManagedDataAccess" Version="19.3.1" />
-	  <PackageReference Include="System.Data.SQLite.Core" Version="1.0.111" />
+	  <PackageReference Include="Oracle.ManagedDataAccess" Version="19.5.0" />
+	  <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Update dependencies and fix table functions support for MSSQL 2017+

- linq2db updated to 2.9.3
- MySql.Data updated to 8.0.18
- Oracle.ManagedDataAccess updated to 19.5.0
- System.Data.SQLite.Core updated to 1.0.112

For SAP HANA 2 SPS04 driver users:
this driver version is full of bugs, that makes it unusable, so it could refuse to work. We tried to workaround one of them, but it still could be not enough.