### PR TITLE
Disable procedures and functions by default

### DIFF
--- a/Source/ConnectionDialog.xaml.cs
+++ b/Source/ConnectionDialog.xaml.cs
@@ -31,7 +31,7 @@ namespace LinqToDB.LINQPad
 				if (args.PropertyName == nameof(ConnectionViewModel.IncludeRoutines) && model.IncludeRoutines)
 				{
 					MessageBox.Show(this,
-						"Including Stored Procedures may be dangerous in production if the selected database driver does not support CommandBehavior.SchemaOnly option.",
+						"Including Stored Procedures may be dangerous in production if the selected database driver does not support CommandBehavior.SchemaOnly option or procedure is not safe for CommandBehavior.SchemaOnly execution mode.",
 						"Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
 				}
 

--- a/Source/DriverHelper.cs
+++ b/Source/DriverHelper.cs
@@ -68,7 +68,7 @@ namespace LinqToDB.LINQPad
 			model.EncryptConnectionString  = cxInfo.DatabaseInfo.EncryptCustomCxString;
 			model.Pluralize                = !cxInfo.DynamicSchemaOptions.NoPluralization;
 			model.Capitalize               = !cxInfo.DynamicSchemaOptions.NoCapitalization;
-			model.IncludeRoutines          = cxInfo.DriverData.Element(CX.ExcludeRoutines)?.Value.ToLower() != "true";
+			model.IncludeRoutines          = cxInfo.DriverData.Element(CX.ExcludeRoutines)?.Value.ToLower() == "false";
 			model.IncludeFKs               = cxInfo.DriverData.Element(CX.ExcludeFKs)?.Value.ToLower()      != "true";
 			model.ConnectionString         = cxInfo.DatabaseInfo.CustomCxString.IsNullOrWhiteSpace() ? (string?)cxInfo.DriverData.Element(CX.ConnectionString) : cxInfo.DatabaseInfo.CustomCxString;
 			model.IncludeSchemas           = cxInfo.DriverData.Element(CX.IncludeSchemas)          ?.Value;

--- a/Source/SchemaAndCodeGenerator.cs
+++ b/Source/SchemaAndCodeGenerator.cs
@@ -72,7 +72,7 @@ namespace LinqToDB.LINQPad
 				var excludeCatalogs = (string?)_cxInfo.DriverData.Element(CX.ExcludeCatalogs);
 				if (excludeCatalogs != null) options.ExcludedCatalogs = excludeCatalogs.Split(',', ';');
 
-				options.GetProcedures  = (string?)_cxInfo.DriverData.Element(CX.ExcludeRoutines) != "true";
+				options.GetProcedures  = (string?)_cxInfo.DriverData.Element(CX.ExcludeRoutines) == "false";
 				options.GetForeignKeys = (string?)_cxInfo.DriverData.Element(CX.ExcludeFKs)      != "true";
 
 				_schema = _dataProvider.GetSchemaProvider().GetSchema(db, options);


### PR DESCRIPTION
Fix #48

- disable procedures load by default for new connections
- update warning text to be more `persuasive`