### PR TITLE
Update dependencies, bump version

### DIFF
--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -1,10 +1,10 @@
 variables:
   solution: 'linq2db.LINQPad.sln'
   build_configuration: 'Release'
-  assemblyVersion: 3.3.1.0
-  nugetVersion: 3.3.1
-  nugetDevVersion: 3.3.1
-  nugetPRVersion: 3.3.1
+  assemblyVersion: 3.3.2.0
+  nugetVersion: 3.3.2
+  nugetDevVersion: 3.3.2
+  nugetPRVersion: 3.3.2
   artifact_lpx: 'lpx'
   artifact_lpx6: 'lpx6'
   artifact_nuget: 'nuget'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,8 +13,7 @@
 		<PackageVersion Include="System.Buffers" Version="4.5.1" />
 		<PackageVersion Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
 
-		<PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="7.10.1" />
-		<PackageVersion Include="MySqlConnector" Version="1.3.2" />
+		<PackageVersion Include="MySqlConnector" Version="1.3.5" />
 		<PackageVersion Include="AdoNetCore.AseClient" Version="0.19.2" />
 		<PackageVersion Include="IBM.Data.DB.Provider" Version="11.5.4000.4861" GeneratePathProperty="true" />
 		<PackageVersion Include="System.Data.SQLite.Core" Version="1.0.113.7" />
@@ -33,10 +32,12 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
 		<PackageVersion Include="Npgsql" Version="4.1.8" />
+		<PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="7.10.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
 		<PackageVersion Include="Npgsql" Version="5.0.4" />
+		<PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="8.0.1" />
 	</ItemGroup>
 </Project>

--- a/Source/SchemaAndCodeGenerator.cs
+++ b/Source/SchemaAndCodeGenerator.cs
@@ -92,11 +92,16 @@ namespace LinqToDB.LINQPad
 				.AppendLine("using LinqToDB.Data;")
 				.AppendLine("using LinqToDB.Mapping;")
 				.AppendLine("using System.Net;")
+				.AppendLine("using System.Numerics;")
 				.AppendLine("using System.Net.NetworkInformation;")
 				.AppendLine("using Microsoft.SqlServer.Types;")
 				;
 
-			if (_schema.Procedures.Any(_ => _.IsAggregateFunction))
+			// TODO: temporary, remove after update to linq2db 3.4.0
+			if (ProviderName == LinqToDB.ProviderName.Firebird)
+				Code.AppendLine("using FirebirdSql.Data.Types;");
+
+				if (_schema.Procedures.Any(_ => _.IsAggregateFunction))
 				Code
 					.AppendLine("using System.Linq.Expressions;")
 					;

--- a/Source/linq2db.LINQPad.csproj
+++ b/Source/linq2db.LINQPad.csproj
@@ -6,7 +6,7 @@
 		<Company>linq2db</Company>
 		<Product>linq2db.LINQPad</Product>
 		<AssemblyTitle>$(Product)</AssemblyTitle>
-		<Version>3.3.1.0</Version>
+		<Version>3.3.2.0</Version>
 		<AssemblyVersion>$(Version)</AssemblyVersion>
 		<FileVersion>$(Version)</FileVersion>
 		<Copyright>Copyright © 2016-2021 Igor Tkachev, Ilya Chudin, Svyatoslav Danyliv, Dmitry Lukashenko</Copyright>

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,10 @@
+# Release 3.3.2
+- [ALL] disable load of procedures and functions by default for new connections
+- [ALL] dependency update: MySqlConnector 1.3.2 -> 1.3.5
+- [ALL] initial support for Firebird 4 types
+- [LINQPAD6] dependency update: FirebirdSql.Data.FirebirdClient 7.10.1 -> 8.0.1
+- [LINQPAD6] improve fix for [#39](https://github.com/linq2db/linq2db.LINQPad/issues/39)
+
 # Release 3.3.1
 - [LINQPAD6] fix incorrect versions for dependencies in nuget version of driver
 


### PR DESCRIPTION
- bump version to 3.3.2
- update mysqlconnector and firebird client dependencies
- fix firebird 4 types support (basic support without linq2db 3.4.0)
- better fix for #39