### PR TITLE
Set CommandTimeout on explicitly created LINQPadDataConnection instances

### DIFF
--- a/Source/LINQPadDataConnection.cs
+++ b/Source/LINQPadDataConnection.cs
@@ -1,4 +1,6 @@
-﻿using LINQPad.Extensibility.DataContext;
+﻿using CodeJam.Strings;
+using CodeJam.Xml;
+using LINQPad.Extensibility.DataContext;
 using LinqToDB.Data;
 
 namespace LinqToDB.LINQPad
@@ -24,6 +26,7 @@ namespace LinqToDB.LINQPad
 				(string?)cxInfo.DriverData.Element(CX.ProviderPath),
 				cxInfo.DatabaseInfo.CustomCxString)
 		{
+			CommandTimeout = cxInfo.DriverData.ElementValueOrDefault(CX.CommandTimeout, str => str.ToInt32() ?? 0, 0);
 		}
 
 		protected virtual void InitMappingSchema()

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,7 @@
 - [ALL] disable load of procedures and functions by default for new connections
 - [ALL] dependency update: MySqlConnector 1.3.2 -> 1.3.5
 - [ALL] initial support for Firebird 4 types
+- [ALL] fix issue with command timeout option being ignored ([#47](https://github.com/linq2db/linq2db.LINQPad/issues/47))
 - [LINQPAD6] dependency update: FirebirdSql.Data.FirebirdClient 7.10.1 -> 8.0.1
 - [LINQPAD6] improve fix for [#39](https://github.com/linq2db/linq2db.LINQPad/issues/39)
 


### PR DESCRIPTION
Fix #47