### PR TITLE
Updated Oracle to fix vulnerability from dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
 		<PackageVersion Include="System.Data.SQLite.Core"                   Version="1.0.115.5"                               />
 		<PackageVersion Include="System.Data.SqlClient"                     Version="4.8.3"                                   />
 		<PackageVersion Include="Oracle.ManagedDataAccess"                  Version="19.13.0"                                 />
-		<PackageVersion Include="Oracle.ManagedDataAccess.Core"             Version="3.21.4"                                  />
+		<PackageVersion Include="Oracle.ManagedDataAccess.Core"             Version="3.21.61"                                  />
 		<PackageVersion Include="System.Data.Odbc"                          Version="6.0.0"                                   />
 		<PackageVersion Include="System.Data.OleDb"                         Version="6.0.0"                                   />
 		<PackageVersion Include="IBM.Data.DB2.Core"                         Version="3.1.0.500"                               />


### PR DESCRIPTION
The NuGet package Oracle.ManagedDataAccess.Core version 3.21.4 uses System.DirectoryServices.Protocols version 5.0.0.

This package has a vulnerability. See https://www.nuget.org/packages/System.DirectoryServices.Protocols/5.0.0.
I noticed this as LinqPad shows a warning.

![grafik](https://user-images.githubusercontent.com/36240951/171990788-149a8136-2ea4-422d-a809-02319e8ae4e3.png)

Therefore updated Oracle.ManagedDataAccess.Core to 3.21.61. This updates System.DirectoryServices.Protocols to 5.0.1 which hasn't got this vulnerability.