### PR TITLE
Fix problems when using a custom IDataContext implementation

### DIFF
--- a/Source/Drivers/DriverHelper.cs
+++ b/Source/Drivers/DriverHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using LINQPad.Extensibility.DataContext;
-using LinqToDB.Common.Logging;
 using LinqToDB.Data;
 using LinqToDB.LINQPad.UI;
 using LinqToDB.Mapping;

--- a/Source/Drivers/DriverHelper.cs
+++ b/Source/Drivers/DriverHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using LINQPad.Extensibility.DataContext;
+using LinqToDB.Common.Logging;
 using LinqToDB.Data;
 using LinqToDB.LINQPad.UI;
 using LinqToDB.Mapping;
@@ -94,6 +95,12 @@ internal static class DriverHelper
 			else if (context is DataContext dctx)
 			{
 				dctx.OnTraceConnection = GetSqlLogAction(executionManager);
+				DataConnection.TurnTraceSwitchOn();
+			}
+			else
+			{
+				// Try to find a OnTraceConnection property in the custom context object
+				context.GetType().GetProperty("OnTraceConnection")?.SetValue(context, GetSqlLogAction(executionManager));
 				DataConnection.TurnTraceSwitchOn();
 			}
 

--- a/Source/Drivers/StaticLinqToDBDriver.cs
+++ b/Source/Drivers/StaticLinqToDBDriver.cs
@@ -105,7 +105,7 @@ public sealed class LinqToDBStaticDriver : StaticDataContextDriver
 	/// <inheritdoc/>
 	public override void InitializeContext(IConnectionInfo cxInfo, object context, QueryExecutionManager executionManager)
 	{
-		_mappingSchema = DriverHelper.InitializeContext(cxInfo, (DataConnection)context, executionManager);
+		_mappingSchema = DriverHelper.InitializeContext(cxInfo, (IDataContext)context, executionManager);
 	}
 
 	/// <inheritdoc/>

--- a/Source/Drivers/StaticLinqToDBDriver.cs
+++ b/Source/Drivers/StaticLinqToDBDriver.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using System.Data.Common;
+using System.IO;
 using LINQPad.Extensibility.DataContext;
 using LinqToDB.Data;
 using LinqToDB.Mapping;
@@ -137,6 +138,12 @@ public sealed class LinqToDBStaticDriver : StaticDataContextDriver
 
 	private void TryLoadAppSettingsJson(string? appConfigPath)
 	{
+		if (string.IsNullOrWhiteSpace(appConfigPath))
+			return;
+
+		if (!File.Exists(appConfigPath))
+			return;
+
 		if (appConfigPath?.EndsWith(".json", StringComparison.OrdinalIgnoreCase) == true)
 			DataConnection.DefaultSettings = AppConfig.LoadJson(appConfigPath);
 #if !NETFRAMEWORK


### PR DESCRIPTION
Some code assumes only DataConnection or DataContext can implement IDataContext. This PR fixes some of these assumptions.

Note: Will try to find a "public Action<TraceInfo> OnTraceConnection" property on the custom IDataContext class. Add something like this If you have a custom implementation that wraps an internal DataContext:

// Important for LinqPad
public Action<TraceInfo> OnTraceConnection { get => Context.OnTraceConnection; set => Context.OnTraceConnection = value; }