### PR TITLE
Implement password manager support for connection strings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -249,6 +249,8 @@ dotnet_diagnostic.MA0006.severity = none
 dotnet_diagnostic.MA0007.severity = none
 # MA0009: Add regex evaluation timeout
 dotnet_diagnostic.MA0009.severity = none
+# MA0023: Add RegexOptions.ExplicitCapture
+dotnet_diagnostic.MA0023.severity = none
 # MA0026: Fix TODO comment
 dotnet_diagnostic.MA0026.severity = none
 # MA0038: Make method static (deprecated, use CA1822 instead)

--- a/Source/Configuration/AppConfig.cs
+++ b/Source/Configuration/AppConfig.cs
@@ -26,7 +26,7 @@ internal sealed class AppConfig(IConnectionStringSettings[] connectionStrings) :
 			if (cn.Key.EndsWith("_ProviderName", StringComparison.InvariantCultureIgnoreCase))
 				continue;
 
-			connections.Add(cn.Key, new ConnectionStringSettings(cn.Key, cn.Value));
+			connections.Add(cn.Key, new ConnectionStringSettings(cn.Key, PasswordManager.ResolvePasswordManagerFields(cn.Value)));
 		}
 
 		foreach (var cn in config.ConnectionStrings)
@@ -64,7 +64,7 @@ internal sealed class AppConfig(IConnectionStringSettings[] connectionStrings) :
 			var providerName     = node.Attributes["providerName"    ]?.Value;
 
 			if (name != null && connectionString != null)
-				settings.Add(new ConnectionStringSettings(name, connectionString) { ProviderName = providerName });
+				settings.Add(new ConnectionStringSettings(name, PasswordManager.ResolvePasswordManagerFields(connectionString)) { ProviderName = providerName });
 		}
 
 		return new AppConfig(settings.ToArray());
@@ -82,11 +82,13 @@ internal sealed class AppConfig(IConnectionStringSettings[] connectionStrings) :
 		public IDictionary<string, string>? ConnectionStrings { get; set; }
 	}
 
+	/// <param name="name">Connection name.</param>
+	/// <param name="connectionString">Must be connection string without password manager tokens.</param>
 	private sealed class ConnectionStringSettings(string name, string connectionString) : IConnectionStringSettings
 	{
 		string IConnectionStringSettings.ConnectionString => connectionString;
-		string  IConnectionStringSettings.Name             => name;
-		bool    IConnectionStringSettings.IsGlobal         => false;
+		string IConnectionStringSettings.Name             => name;
+		bool   IConnectionStringSettings.IsGlobal         => false;
 
 		public string? ProviderName { get; set; }
 	}

--- a/Source/Configuration/ConnectionSettings.cs
+++ b/Source/Configuration/ConnectionSettings.cs
@@ -388,6 +388,18 @@ internal sealed class ConnectionSettings
 		public string? ConnectionString { get; set; }
 
 		/// <summary>
+		/// Returns <see cref="ConnectionString"/> property value with resolved LINQPad password manager tokens.
+		/// </summary>
+		/// <returns></returns>
+		public string? GetFullConnectionString         () => PasswordManager.ResolvePasswordManagerFields(ConnectionString);
+
+		/// <summary>
+		/// Returns <see cref="SecondaryConnectionString"/> property value with resolved LINQPad password manager tokens.
+		/// </summary>
+		/// <returns></returns>
+		public string? GetFullSecondaryConnectionString() => PasswordManager.ResolvePasswordManagerFields(SecondaryConnectionString);
+
+		/// <summary>
 		/// Stored in <see cref="IDatabaseInfo.Provider"/>.
 		/// </summary>
 		[JsonIgnore]

--- a/Source/DatabaseProviders/DatabaseProviderBase.cs
+++ b/Source/DatabaseProviders/DatabaseProviderBase.cs
@@ -30,6 +30,9 @@ internal abstract class DatabaseProviderBase(string database, string description
 	public abstract DateTime?         GetLastSchemaUpdate(ConnectionSettings settings);
 	public abstract DbProviderFactory GetProviderFactory (string providerName        );
 
+	/// <param name="providerName">Provider name.</param>
+	/// <param name="connectionString">Connection string must be resolved against password manager already.</param>
+	/// <returns></returns>
 	public virtual IDataProvider GetDataProvider(string providerName, string connectionString)
 	{
 		return DataConnection.GetDataProvider(providerName, connectionString)

--- a/Source/DatabaseProviders/DatabaseProviders.cs
+++ b/Source/DatabaseProviders/DatabaseProviders.cs
@@ -64,12 +64,21 @@ internal static class DatabaseProviders
 		// trigger .cctors
 	}
 
-	public static DbConnection CreateConnection (ConnectionSettings settings) => GetDataProvider(settings).CreateConnection(settings.Connection.ConnectionString!);
+	public static DbConnection CreateConnection(ConnectionSettings settings)
+	{
+		return GetDataProvider(settings).CreateConnection(settings.Connection.GetFullConnectionString()!);
+	}
 
 	public static DbProviderFactory GetProviderFactory(ConnectionSettings settings) => GetProviderByName(settings.Connection.Provider!).GetProviderFactory(settings.Connection.Provider!);
 
-	public static IDataProvider GetDataProvider(ConnectionSettings settings) => GetDataProvider(settings.Connection.Provider, settings.Connection.ConnectionString, settings.Connection.ProviderPath);
+	public static IDataProvider GetDataProvider(ConnectionSettings settings)
+	{
+		return GetDataProvider(settings.Connection.Provider, settings.Connection.GetFullConnectionString(), settings.Connection.ProviderPath);
+	}
 
+	/// <param name="providerName">Provider name.</param>
+	/// <param name="connectionString">Connection string must be already resolved against password manager.</param>
+	/// <param name="providerPath">Optional path to provider assembly.</param>
 	public static IDataProvider GetDataProvider(string? providerName, string? connectionString, string? providerPath)
 	{
 		if (string.IsNullOrWhiteSpace(providerName))

--- a/Source/DatabaseProviders/IDatabaseProvider.cs
+++ b/Source/DatabaseProviders/IDatabaseProvider.cs
@@ -53,6 +53,8 @@ internal interface IDatabaseProvider
 	/// <summary>
 	/// Tries to infer provider by database connection string.
 	/// </summary>
+	/// <param name="connectionString">Connection string could contain password manager tokens.</param>
+	/// <returns></returns>
 	ProviderInfo? GetProviderByConnectionString(string connectionString);
 
 	/// <summary>
@@ -95,6 +97,8 @@ internal interface IDatabaseProvider
 	/// <summary>
 	/// Returns linq2db data provider.
 	/// </summary>
+	/// <param name="providerName">Provider name.</param>
+	/// <param name="connectionString">Connection string must be already resolved against password manager.</param>
 	IDataProvider GetDataProvider(string providerName, string connectionString);
 
 #if NETFRAMEWORK

--- a/Source/DatabaseProviders/SqlServerProvider.cs
+++ b/Source/DatabaseProviders/SqlServerProvider.cs
@@ -92,7 +92,6 @@ internal sealed class SqlServerProvider : DatabaseProviderBase
 		return SqlClientFactory.Instance;
 	}
 
-
 	public override IDataProvider GetDataProvider(string providerName, string connectionString)
 	{
 		// provider detector fails to detect Microsoft.Data.SqlClient

--- a/Source/Drivers/DriverHelper.cs
+++ b/Source/Drivers/DriverHelper.cs
@@ -266,17 +266,18 @@ internal static class DriverHelper
 						throw new LinqToDBLinqPadException($"Cannot access provider assembly at {model.DynamicConnection.ProviderPath}");
 				}
 
-				var provider = DatabaseProviders.GetDataProvider(model.DynamicConnection.Provider.Name, model.DynamicConnection.ConnectionString, model.DynamicConnection.ProviderPath);
-
-				using (var con = provider.CreateConnection(model.DynamicConnection.ConnectionString))
+				var connectionString = PasswordManager.ResolvePasswordManagerFields(model.DynamicConnection.ConnectionString);
+				var provider         = DatabaseProviders.GetDataProvider(model.DynamicConnection.Provider.Name, connectionString, model.DynamicConnection.ProviderPath);
+				using (var con       = provider.CreateConnection(connectionString))
 					con.Open();
 
 				if (model.DynamicConnection.Database.SupportsSecondaryConnection
 					&& model.DynamicConnection.SecondaryProvider != null
 					&& model.DynamicConnection.SecondaryConnectionString != null)
 				{
-					var secondaryProvider = DatabaseProviders.GetDataProvider(model.DynamicConnection.SecondaryProvider.Name, model.DynamicConnection.SecondaryConnectionString, null);
-					using var con = secondaryProvider.CreateConnection(model.DynamicConnection.SecondaryConnectionString);
+					var secondaryConnectionString = PasswordManager.ResolvePasswordManagerFields(model.DynamicConnection.SecondaryConnectionString);
+					var secondaryProvider         = DatabaseProviders.GetDataProvider(model.DynamicConnection.SecondaryProvider.Name, secondaryConnectionString, null);
+					using var con                 = secondaryProvider.CreateConnection(secondaryConnectionString);
 					con.Open();
 				}
 

--- a/Source/Drivers/DynamicLinqToDBDriver.cs
+++ b/Source/Drivers/DynamicLinqToDBDriver.cs
@@ -197,7 +197,7 @@ public sealed class LinqToDBDriver : DynamicDataContextDriver
 			[
 				settings.Connection.Provider,
 				settings.Connection.ProviderPath,
-				settings.Connection.ConnectionString
+				settings.Connection.GetFullConnectionString()
 			];
 		}
 		catch (Exception ex)

--- a/Source/Drivers/DynamicSchemaGenerator.cs
+++ b/Source/Drivers/DynamicSchemaGenerator.cs
@@ -132,7 +132,7 @@ internal static class DynamicSchemaGenerator
 
 		var provider         = DatabaseProviders.GetDataProvider(settings);
 
-		using var db         = new DataConnection(provider, settings.Connection.ConnectionString!);
+		using var db         = new DataConnection(provider, settings.Connection.GetFullConnectionString()!);
 		if (settings.Connection.CommandTimeout != null)
 			db.CommandTimeout = settings.Connection.CommandTimeout.Value;
 
@@ -150,8 +150,9 @@ internal static class DynamicSchemaGenerator
 		DatabaseModel dataModel;
 		if (settings.Connection.Database == ProviderName.Access && settings.Connection.SecondaryConnectionString != null)
 		{
-			var secondaryProvider = DatabaseProviders.GetDataProvider(settings.Connection.SecondaryProvider, settings.Connection.SecondaryConnectionString, null);
-			using var sdc         = new DataConnection(secondaryProvider, settings.Connection.SecondaryConnectionString);
+			var secondaryConnectionString = settings.Connection.GetFullSecondaryConnectionString()!;
+			var secondaryProvider         = DatabaseProviders.GetDataProvider(settings.Connection.SecondaryProvider, secondaryConnectionString, null);
+			using var sdc                 = new DataConnection(secondaryProvider, secondaryConnectionString);
 
 			if (settings.Connection.CommandTimeout != null)
 				sdc.CommandTimeout = settings.Connection.CommandTimeout.Value;

--- a/Source/Drivers/PasswordManager.cs
+++ b/Source/Drivers/PasswordManager.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using LINQPad;
+
+namespace LinqToDB.LINQPad
+{
+	internal static partial class PasswordManager
+	{
+		private static readonly Regex _tokenReplacer = new(@"\{pm:([^\}]+)\}", RegexOptions.Compiled);
+
+		[return: NotNullIfNotNull(nameof(value))]
+		public static string? ResolvePasswordManagerFields(string? value)
+		{
+			if (value == null)
+				return null;
+
+			return _tokenReplacer.Replace(value, m => Util.GetPassword(m.Groups[1].Value));
+		}
+	}
+}

--- a/Source/LINQPadDataConnection.cs
+++ b/Source/LINQPadDataConnection.cs
@@ -10,6 +10,9 @@ public class LINQPadDataConnection : DataConnection
 	/// <summary>
 	/// Constructor for inherited context.
 	/// </summary>
+	/// <param name="providerName">Provider name.</param>
+	/// <param name="providerPath">Optional provider assembly path.</param>
+	/// <param name="connectionString">Connection string must have password manager tokens replaced already.</param>
 	protected LINQPadDataConnection(string? providerName, string? providerPath, string? connectionString)
 		: base(
 			DatabaseProviders.GetDataProvider(providerName, connectionString, providerPath),
@@ -24,7 +27,7 @@ public class LINQPadDataConnection : DataConnection
 		: this(
 			settings.Connection.Provider,
 			settings.Connection.ProviderPath,
-			settings.Connection.ConnectionString)
+			settings.Connection.GetFullConnectionString())
 	{
 		if (settings.Connection.CommandTimeout != null)
 			CommandTimeout = settings.Connection.CommandTimeout.Value;

--- a/Source/UI/Settings/DynamicConnectionTab.xaml
+++ b/Source/UI/Settings/DynamicConnectionTab.xaml
@@ -39,7 +39,7 @@
 					<TextBox Padding="5" Text="{Binding ProviderPath}" />
 				</DockPanel>
 
-				<StackPanel Margin="0 5 0 0" ToolTip="Specify database connection string">
+				<StackPanel Margin="0 5 0 0" ToolTip="Specify database connection string. Connection string could reference values from LINPad Password Manager (see File -> Password Manager) using following format: {pm:name}, e.g. &quot;Server=.;Database=DB;User Id=user;Password={pm:my-password}&quot;">
 					<Label>Connection string</Label>
 					<TextBox Padding="5" Text="{Binding ConnectionString}" TextWrapping="Wrap" Height="60" VerticalScrollBarVisibility="Auto" />
 				</StackPanel>

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,7 @@
 
 Issues fixed:
 
+- [#88](https://github.com/linq2db/linq2db.LINQPad/issues/88): add support for LINQPad Password Manager in connection strings. To reference value from password manager use `{pm:password-name}` token syntax
 - [#97](https://github.com/linq2db/linq2db.LINQPad/issues/97), [#103](https://github.com/linq2db/linq2db.LINQPad/issues/103): update dependencies to get rid of vulnerable transient dependencies
 - [#101](https://github.com/linq2db/linq2db.LINQPad/issues/101): fix snippets generation from object names matching C# keywords
 - [#102](https://github.com/linq2db/linq2db.LINQPad/pull/102): support custom `IDataContext`-based contexts; don't try to load missing connection configuration files. Thanks to [@cal-tlabwest](https://github.com/cal-tlabwest) for fix


### PR DESCRIPTION
Fix #88

To use passwords (or any other string value, e.g. whole connection string) from password manager user should place token in following format in main or secondary connection string value: `{pm:name-of-value-in-password-manager}`. E.g. `{pm:mypassword}`