### PR TITLE
Re-enable DB2 for iSeries support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
 		<PackageVersion Include="FirebirdSql.Data.FirebirdClient"           Version="10.3.1"                                  />
 		<PackageVersion Include="Npgsql"                                    Version="8.0.3"                                   />
 		<PackageVersion Include="Octonica.ClickHouseClient"                 Version="3.1.3"                                   />
-		<!--<PackageVersion Include="linq2db4iSeries"                           Version="5.1.0"                                   />-->
+		<PackageVersion Include="linq2db4iSeries"                           Version="5.4.0"                                   />
 
 		<PackageVersion Include="Microsoft.SqlServer.Types"                 Version="160.1000.6"                              />
 	</ItemGroup>

--- a/Source/DatabaseProviders/DB2Provider.cs
+++ b/Source/DatabaseProviders/DB2Provider.cs
@@ -1,5 +1,7 @@
 ﻿using LinqToDB.Data;
 using System.Data.Common;
+using LinqToDB.DataProvider.DB2iSeries;
+
 #if NETFRAMEWORK
 using IBM.Data.DB2;
 #else
@@ -15,13 +17,13 @@ internal sealed class DB2Provider : DatabaseProviderBase
 		new (ProviderName.DB2LUW       , "DB2 for Linux, UNIX and Windows (LUW)"),
 		// zOS provider not tested at all as we don't have access to database instance
 		new (ProviderName.DB2zOS       , "DB2 for z/OS"                         ),
-		//new (DB2iSeriesProviderName.DB2, "DB2 for i (iSeries)"                  ),
+		new (DB2iSeriesProviderName.DB2, "DB2 for i (iSeries)"                  ),
 	];
 
 	public DB2Provider()
-		//: base(ProviderName.DB2, "IBM DB2 (LUW, z/OS or iSeries)", _providers)
-		: base(ProviderName.DB2, "IBM DB2 (LUW or z/OS)", _providers)
+		: base(ProviderName.DB2, "IBM DB2 (LUW, z/OS or iSeries)", _providers)
 	{
+		DataConnection.AddProviderDetector(DB2iSeriesTools.ProviderDetector);
 	}
 
 	public override void ClearAllPools(string providerName)
@@ -35,7 +37,7 @@ internal sealed class DB2Provider : DatabaseProviderBase
 		{
 			ProviderName.DB2LUW        => "SELECT MAX(TIME) FROM (SELECT MAX(ALTER_TIME) AS TIME FROM SYSCAT.ROUTINES UNION SELECT MAX(ALTER_TIME) AS TIME FROM SYSCAT.TABLES)",
 			ProviderName.DB2zOS        => "SELECT MAX(TIME) FROM (SELECT MAX(ALTEREDTS) AS TIME FROM SYSIBM.SYSROUTINES UNION SELECT MAX(ALTEREDTS) AS TIME FROM SYSIBM.SYSTABLES)",
-			//DB2iSeriesProviderName.DB2 => "SELECT MAX(TIME) FROM (SELECT MAX(LAST_ALTERED) AS TIME FROM QSYS2.SYSROUTINES UNION SELECT MAX(ROUTINE_CREATED) AS TIME FROM QSYS2.SYSROUTINES UNION SELECT MAX(LAST_ALTERED_TIMESTAMP) AS TIME FROM QSYS2.SYSTABLES)",
+			DB2iSeriesProviderName.DB2 => "SELECT MAX(TIME) FROM (SELECT MAX(LAST_ALTERED) AS TIME FROM QSYS2.SYSROUTINES UNION SELECT MAX(ROUTINE_CREATED) AS TIME FROM QSYS2.SYSROUTINES UNION SELECT MAX(LAST_ALTERED_TIMESTAMP) AS TIME FROM QSYS2.SYSTABLES)",
 			_                          => throw new LinqToDBLinqPadException($"Unknown DB2 provider '{settings.Connection.Provider}'")
 		};
 

--- a/Source/linq2db.LINQPad.csproj
+++ b/Source/linq2db.LINQPad.csproj
@@ -61,7 +61,7 @@
 		<PackageReference Include="Microsoft.Data.SqlClient" />
 		<PackageReference Include="Npgsql" />
 		<PackageReference Include="ClickHouse.Client" />
-		<!--<PackageReference Include="linq2db4iSeries" />-->
+		<PackageReference Include="linq2db4iSeries" />
 		<PackageReference Include="Microsoft.SqlServer.Types" />
 
 		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" />


### PR DESCRIPTION
Re-enabling support for DB2 for iSeries via the Linq2DB4iSeries package