### PR TITLE
linq2db 6 migration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -265,9 +265,15 @@ dotnet_diagnostic.MA0051.severity = none
 dotnet_diagnostic.MA0053.severity = none
 # MA0101: String contains an implicit end of line character
 dotnet_diagnostic.MA0101.severity = none
+# MA0110: Use the Regex source generator
+dotnet_diagnostic.MA0110.severity = none
 # MA0111: Use string.Create instead of FormattableString
 dotnet_diagnostic.MA0111.severity = none
 # MA0144: Use System.OperatingSystem to check the current OS
 dotnet_diagnostic.MA0144.severity = none
 # MA0154: Use langword in XML comment
 dotnet_diagnostic.MA0154.severity = none
+# MA0159: Use Order instead of OrderBy
+dotnet_diagnostic.MA0159.severity = none
+# MA0165: Make interpolated string
+dotnet_diagnostic.MA0165.severity = none

--- a/Build/BuildNuspecs.ps1
+++ b/Build/BuildNuspecs.ps1
@@ -37,7 +37,7 @@ if ($version) {
 		$xml.package.metadata.AppendChild($child)
 
 		$child = $xml.CreateElement('copyright', $nsUri)
-		$child.InnerText = 'Copyright © 2016-2024 ' + $authors
+		$child.InnerText = 'Copyright © 2016-2025 ' + $authors
 		$xml.package.metadata.AppendChild($child)
 
 		$child = $xml.CreateElement('authors', $nsUri)

--- a/Build/Pack.cmd
+++ b/Build/Pack.cmd
@@ -1,36 +1,39 @@
-ECHO OFF
+ECHO ON
 ECHO Packing %2
 
-DEL linq2db.LINQPad.%2
-DEL linq2db.LINQPad.%2.zip
+SET RELDIR=%1..\..\..\..\releases
+SET RESDIR=%1..\..\..\..\..\Build
+
+DEL %RELDIR%\linq2db.LINQPad.%2
+DEL %RELDIR%\linq2db.LINQPad.%2.zip
 
 REM LINQPad 5 driver archive generation
 IF %2 EQU lpx (
 	REM remove resource satellite assemblies
-	RD /S /Q %1\cs
-	RD /S /Q %1\de
-	RD /S /Q %1\es
-	RD /S /Q %1\fr
-	RD /S /Q %1\it
-	RD /S /Q %1\ja
-	RD /S /Q %1\ko
-	RD /S /Q %1\pl
-	RD /S /Q %1\pt
-	RD /S /Q %1\pt-BR
-	RD /S /Q %1\ru
-	RD /S /Q %1\tr
-	RD /S /Q %1\zh-Hans
-	RD /S /Q %1\zh-Hant
+	RD /S /Q %1cs
+	RD /S /Q %1de
+	RD /S /Q %1es
+	RD /S /Q %1fr
+	RD /S /Q %1it
+	RD /S /Q %1ja
+	RD /S /Q %1ko
+	RD /S /Q %1pl
+	RD /S /Q %1pt
+	RD /S /Q %1pt-BR
+	RD /S /Q %1ru
+	RD /S /Q %1tr
+	RD /S /Q %1zh-Hans
+	RD /S /Q %1zh-Hant
 
 	REM remove not needed files
-	DEL /Q %1\linq2db.*.xml
-	DEL /Q %1\*.pdb
+	DEL /Q %1linq2db.*.xml
+	DEL /Q %1*.pdb
 
-	"C:\Program Files\7-Zip\7z.exe" -r a linq2db.LINQPad.%2.zip %1\*.* %1\..\..\..\..\Build\Connection.png %1\..\..\..\..\Build\FailedConnection.png %1\..\..\..\..\Build\header.xml
+	"C:\Program Files\7-Zip\7z.exe" -r a %RELDIR%\linq2db.LINQPad.%2.zip %1*.* %RESDIR%\Connection.png %RESDIR%\FailedConnection.png %RESDIR%\header.xml
 )
 
 REM LINQPad 7 driver archive generation
-IF %2 EQU lpx6 ("C:\Program Files\7-Zip\7z.exe" a linq2db.LINQPad.%2.zip %1\linq2db.LINQPad.dll %1\..\..\..\..\Build\Connection.png %1\..\..\..\..\Build\FailedConnection.png %1\linq2db.LINQPad.deps.json)
+IF %2 EQU lpx6 ("C:\Program Files\7-Zip\7z.exe" a %RELDIR%\linq2db.LINQPad.%2.zip %1linq2db.LINQPad.dll %RESDIR%\Connection.png %RESDIR%\FailedConnection.png %1linq2db.LINQPad.deps.json)
 
-REN linq2db.LINQPad.%2.zip linq2db.LINQPad.%2
+REN %RELDIR%\linq2db.LINQPad.%2.zip linq2db.LINQPad.%2
 

--- a/Build/README.md
+++ b/Build/README.md
@@ -1,11 +1,12 @@
-# LINQ to DB LINQPad 7 Driver
+# LINQ to DB LINQPad 8 Driver
 
-This nuget package is a driver for [LINQPad 7](http://www.linqpad.net). Support for LINQPad 6 is available via older 4.x drivers.
+This nuget package is a driver for [LINQPad 8](http://www.linqpad.net). Support for older versions of LINQPad is available via older versions drivers.
 
 Following databases supported:
 
 - **ClickHouse**: using Binary, HTTP and MySQL interfaces
-- **DB2** (LUW, z/OS): x64-bit version of LINQPad only
+- **DB2** (LUW, z/OS, iSeries): x64-bit version of LINQPad only
+- **DB2 iSeries**: check release notes to see which version supports this database
 - **Firebird**
 - **Informix**: x64-bit version of LINQPad only
 - **Microsoft Access**: both OLE DB and ODBC drivers

--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -40,11 +40,11 @@ stages:
         arguments: -path $(Build.SourcesDirectory)/Source/linq2db.LINQPad.csproj -version $(assemblyVersion)
       displayName: Update Assembly Version
 
-    - task: MSBuild@1
+    - task: DotNetCoreCLI@2
       inputs:
-        solution: '$(solution)'
+        command: build
+        projects: '$(solution)'
         configuration: '$(build_configuration)'
-        msbuildArguments: '/t:Restore;Rebuild -m'
       displayName: Build Solution
 
     - task: PublishPipelineArtifact@1

--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -1,10 +1,10 @@
 variables:
   solution: 'linq2db.LINQPad.sln'
   build_configuration: 'Release'
-  assemblyVersion: 5.4.2.0
-  nugetVersion: 5.4.2
-  nugetDevVersion: 5.4.3
-  nugetPRVersion: 5.4.3
+  assemblyVersion: 6.0.0-preview.3
+  nugetVersion: 6.0.0
+  nugetDevVersion: 6.0.0
+  nugetPRVersion: 6.0.0
   artifact_lpx: 'lpx'
   artifact_lpx6: 'lpx6'
   artifact_nuget: 'nuget'
@@ -49,13 +49,13 @@ stages:
 
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(Build.SourcesDirectory)/Source/linq2db.LINQPad.lpx'
+        path: '$(Build.SourcesDirectory)/.build/releases/linq2db.LINQPad.lpx'
         artifact: '$(artifact_lpx)'
       displayName: Publish .LPX to Artifacts
 
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(Build.SourcesDirectory)/Source/linq2db.LINQPad.lpx6'
+        path: '$(Build.SourcesDirectory)/.build/releases/linq2db.LINQPad.lpx6'
         artifact: '$(artifact_lpx6)'
       displayName: Publish .LPX6 to Artifacts
 
@@ -78,13 +78,13 @@ stages:
     - task: NuGetCommand@2
       inputs:
         command: 'custom'
-        arguments: 'pack "$(Build.SourcesDirectory)/Build/linq2db.LINQPad.nuspec" -OutputDirectory "$(Build.SourcesDirectory)/Build/built"'
+        arguments: 'pack "$(Build.SourcesDirectory)/Build/linq2db.LINQPad.nuspec" -OutputDirectory "$(Build.SourcesDirectory)/.build/nugets"'
       condition: or (eq(variables['Build.SourceBranchName'], 'master'), eq(variables['Build.SourceBranchName'], 'release'))
       displayName: Generate linq2db.LINQPad.nupkg
 
     - task: PublishPipelineArtifact@1
       inputs:
-        path: '$(Build.SourcesDirectory)/Build/built/'
+        path: '$(Build.SourcesDirectory)/.build/nugets/'
         artifact: '$(artifact_nuget)'
       condition: or (eq(variables['Build.SourceBranchName'], 'master'), eq(variables['Build.SourceBranchName'], 'release'))
       displayName: Publish nuget to Artifacts
@@ -92,7 +92,7 @@ stages:
     - task: NuGetCommand@2
       inputs:
         command: 'push'
-        packagesToPush: '$(Build.SourcesDirectory)/Build/built/*.nupkg'
+        packagesToPush: '$(Build.SourcesDirectory)/.build/nugets/*.nupkg'
         nuGetFeedType: 'internal'
         publishVstsFeed: '0dcc414b-ea54-451e-a54f-d63f05367c4b/967a4107-9788-41a4-9f6d-a2318aab1410'
       displayName: Publish to Azure Artifacts feed
@@ -101,7 +101,7 @@ stages:
     - task: NuGetCommand@2
       inputs:
         command: 'push'
-        packagesToPush: '$(Build.SourcesDirectory)/Build/built/*.nupkg'
+        packagesToPush: '$(Build.SourcesDirectory)/.build/nugets/*.nupkg'
         nuGetFeedType: 'external'
         publishFeedCredentials: 'linq2db nuget.org feed'
       displayName: Publish to Nuget.org

--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -1,8 +1,8 @@
 variables:
   solution: 'linq2db.LINQPad.sln'
   build_configuration: 'Release'
-  assemblyVersion: 6.0.0-preview.3
-  nugetVersion: 6.0.0
+  assemblyVersion: 6.0.0
+  nugetVersion: 6.0.0-preview.3
   nugetDevVersion: 6.0.0
   nugetPRVersion: 6.0.0
   artifact_lpx: 'lpx'

--- a/Build/linq2db.LINQPad.nuspec
+++ b/Build/linq2db.LINQPad.nuspec
@@ -10,42 +10,42 @@
 		</tags>
 		<readme>README.md</readme>
 		<dependencies>
-			<group targetFramework="net6.0">
-				<dependency id="linq2db"                                   version="5.4.1"      />
-				<dependency id="linq2db.Tools"                             version="5.4.1"      />
+			<group targetFramework="net8.0">
+				<dependency id="linq2db.Tools"                             version="6.0.0-preview.3" />
+				<dependency id="linq2db.Scaffold"                          version="6.0.0-preview.3" />
 
 				<dependency id="LINQPad.Reference"                         version="1.3.1"      />
 
-				<dependency id="System.Configuration.ConfigurationManager" version="8.0.1"      />
-				<dependency id="Microsoft.CodeAnalysis.CSharp"             version="4.11.0"     />
+				<dependency id="System.Configuration.ConfigurationManager" version="9.0.1"      />
+				<dependency id="Microsoft.CodeAnalysis.CSharp"             version="4.12.0"     />
 
-				<dependency id="FirebirdSql.Data.FirebirdClient"           version="10.3.1"     />
-				<dependency id="MySqlConnector"                            version="2.3.7"      />
+				<dependency id="FirebirdSql.Data.FirebirdClient"           version="10.3.2"     />
+				<dependency id="MySqlConnector"                            version="2.4.0"      />
 				<dependency id="AdoNetCore.AseClient"                      version="0.19.2"     />
 				<dependency id="System.Data.SQLite.Core"                   version="1.0.119"    />
-				<dependency id="Microsoft.Data.SqlClient"                  version="5.2.2"      />
+				<dependency id="Microsoft.Data.SqlClient"                  version="6.0.1"      />
 				<dependency id="Microsoft.SqlServer.Types"                 version="160.1000.6" />
-				<dependency id="System.Data.Odbc"                          version="8.0.1"      />
-				<dependency id="System.Data.OleDb"                         version="8.0.1"      />
-				<dependency id="Npgsql"                                    version="8.0.4"      />
-				<dependency id="Oracle.ManagedDataAccess.Core"             version="23.6.0"     />
-				<dependency id="Net.IBM.Data.Db2"                          version="7.0.0.400"  />
-				<dependency id="ClickHouse.Client"                         version="7.8.0"      />
+				<dependency id="System.Data.Odbc"                          version="9.0.1"      />
+				<dependency id="System.Data.OleDb"                         version="9.0.1"      />
+				<dependency id="Npgsql"                                    version="9.0.2"      />
+				<dependency id="Oracle.ManagedDataAccess.Core"             version="23.7.0"     />
+				<dependency id="Net.IBM.Data.Db2"                          version="8.0.0.300"  />
+				<dependency id="ClickHouse.Client"                         version="7.10.0"     />
 				<dependency id="Octonica.ClickHouseClient"                 version="3.1.3"      />
-				<dependency id="linq2db4iSeries"                           version="5.4.0"      />
+				<!--<dependency id="linq2db4iSeries"                           version="5.4.0"      />-->
 			</group>
 		</dependencies>
 		<frameworkReferences>
-			<group targetFramework="net6.0">
+			<group targetFramework="net8.0">
 				<frameworkReference name="Microsoft.WindowsDesktop.App.WPF" />
 			</group>
 		</frameworkReferences>
 	</metadata>
 
 	<files>
-		<file src="..\Source\bin\Release\net6.0-windows\linq2db.LINQPad.dll" target="lib\net6.0\" />
-		<file src="Connection.png"                                           target="lib\net6.0\" />
-		<file src="FailedConnection.png"                                     target="lib\net6.0\" />
-		<file src="README.md"                                                                     />
+		<file src="..\.build\bin\linq2db.LINQPad\Release\net8.0-windows\linq2db.LINQPad.dll" target="lib\net8.0\" />
+		<file src="Connection.png"                                                           target="lib\net8.0\" />
+		<file src="FailedConnection.png"                                                     target="lib\net8.0\" />
+		<file src="README.md"                                                                                     />
 	</files>
 </package>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<ArtifactsPath>$(MSBuildThisFileDirectory).build</ArtifactsPath>
+		<ArtifactsPivots>$(Configuration)\$(TargetFramework)</ArtifactsPivots>
+	</PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,41 +1,47 @@
 ﻿<Project>
 	<ItemGroup>
-		<PackageVersion Include="linq2db"                                   Version="5.4.1"                                   />
-		<PackageVersion Include="linq2db.Tools"                             Version="5.4.1"                                   />
+		<!--temporary due to bad nuget dep-->
+		<PackageVersion Include="linq2db.Tools"                             Version="6.0.0-preview.3"                         />
+		<PackageVersion Include="linq2db.Scaffold"                          Version="6.0.0-preview.3"                         />
 
 		<PackageVersion Include="LINQPad.Reference"                         Version="1.3.1"                                   />
 		
-		<PackageVersion Include="PolySharp"                                 Version="1.14.1"                                  />
+		<PackageVersion Include="PolySharp"                                 Version="1.15.0"                                  />
 
-		<PackageVersion Include="Meziantou.Analyzer"                        Version="2.0.169"                                 />
-		<PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.11.0-beta1.24454.1"                    />
-		<PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers"       Version="9.0.0-preview.24454.1"                   />
+		<PackageVersion Include="Meziantou.Analyzer"                        Version="2.0.186"                                 />
+		<PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.11.0-beta1.24605.2"                    />
+		<PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers"       Version="9.0.0-preview.24605.2"                   />
 
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp"             Version="4.11.0"                                  />
-		<PackageVersion Include="System.ValueTuple"                         Version="4.5.0"                                   />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp"             Version="4.12.0"                                  />
+
+		<!-- must be pinned to avoid LinqPAD 5 issues (it will not show in list of available connections in Add connection dialog).
+			   Meaning some other dependencies that need 4.6.0+ version
+				 also should be pinned for netfx:
+				 FirebirdClient: pinned to 10.3.1
+		-->
 		<PackageVersion Include="System.Threading.Tasks.Extensions"         Version="4.5.4"                                   />
-		<PackageVersion Include="System.Runtime.CompilerServices.Unsafe"    Version="6.0.0"                                   />
-		<PackageVersion Include="System.Memory"                             Version="4.5.5"                                   />
-		<PackageVersion Include="System.Buffers"                            Version="4.5.1"                                   />
-		<PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1"                                   />
-		<!--don't update those two to 8+ till linq2db reference Microsoft.Bcl.AsyncInterfaces v7 in netfx build-->
-		<PackageVersion Include="System.Text.Json"                          Version="7.0.4"                                   />
-		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces"             Version="7.0.0"                                   />
+		
+		<PackageVersion Include="System.Runtime.CompilerServices.Unsafe"    Version="6.1.0"                                   />
+		<PackageVersion Include="System.Memory"                             Version="4.6.0"                                   />
+		<PackageVersion Include="System.Buffers"                            Version="4.6.0"                                   />
+		<PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.1"                                   />
+		<PackageVersion Include="System.Text.Json"                          Version="9.0.1"                                   />
 
 		<PackageVersion Include="System.Data.SQLite.Core"                   Version="1.0.119"                                 />
-		<PackageVersion Include="System.Data.Odbc"                          Version="8.0.1"                                   />
-		<PackageVersion Include="System.Data.OleDb"                         Version="8.0.1"                                   />
-		<PackageVersion Include="MySqlConnector"                            Version="2.3.7"                                   />
+		<PackageVersion Include="System.Data.Odbc"                          Version="9.0.1"                                   />
+		<PackageVersion Include="System.Data.OleDb"                         Version="9.0.1"                                   />
+		<PackageVersion Include="MySqlConnector"                            Version="2.4.0"                                   />
 		<PackageVersion Include="AdoNetCore.AseClient"                      Version="0.19.2"                                  />
 		<PackageVersion Include="IBM.Data.DB.Provider"                      Version="11.5.9000.4" GeneratePathProperty="true" />
-		<PackageVersion Include="Microsoft.Data.SqlClient"                  Version="5.2.2"                                   />
-		<PackageVersion Include="Oracle.ManagedDataAccess"                  Version="23.6.0"                                  />
-		<PackageVersion Include="Oracle.ManagedDataAccess.Core"             Version="23.6.0"                                  />
-		<!--don't update to v8+ as we need to support net6.0 TFM-->
-		<PackageVersion Include="Net.IBM.Data.Db2"                          Version="7.0.0.400"                               />
-		<PackageVersion Include="ClickHouse.Client"                         Version="7.8.0"                                   />
-		<PackageVersion Include="FirebirdSql.Data.FirebirdClient"           Version="10.3.1"                                  />
-		<PackageVersion Include="Npgsql"                                    Version="8.0.4"                                   />
+		<PackageVersion Include="Microsoft.Data.SqlClient"                  Version="6.0.1"                                   />
+		<PackageVersion Include="Oracle.ManagedDataAccess"                  Version="23.7.0"                                  />
+		<PackageVersion Include="Oracle.ManagedDataAccess.Core"             Version="23.7.0"                                  />
+		<PackageVersion Include="Net.IBM.Data.Db2"                          Version="8.0.0.300"                               />
+		<PackageVersion Include="ClickHouse.Client"                         Version="7.10.0"                                  />
+		<PackageVersion Include="FirebirdSql.Data.FirebirdClient"           Version="10.3.2"                Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))"  />
+		<PackageVersion Include="FirebirdSql.Data.FirebirdClient"           Version="10.3.1"                Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
+		<PackageVersion Include="Npgsql"                                    Version="9.0.2"                 Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))"  />
+		<PackageVersion Include="Npgsql"                                    Version="8.0.6"                 Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
 		<PackageVersion Include="Octonica.ClickHouseClient"                 Version="3.1.3"                                   />
 		<PackageVersion Include="linq2db4iSeries"                           Version="5.4.0"                                   />
 

--- a/MIT-LICENSE.txt
+++ b/MIT-LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2024 Linq To DB Team
+Copyright (c) 2016-2025 Linq To DB Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # LINQ to DB LINQPad Driver
 
-[![NuGet Version and Downloads count](https://buildstats.info/nuget/linq2db.LINQPad?includePreReleases=true)](https://www.nuget.org/packages/linq2db.LINQPad) [![License](https://img.shields.io/github/license/linq2db/linq2db.LINQPad)](MIT-LICENSE.txt)
+[![NuGet Version](https://img.shields.io/nuget/vpre/linq2db.linqpad)](https://www.nuget.org/profiles/LinqToDB.LINQPad) [![License](https://img.shields.io/github/license/linq2db/linq2db.LINQPad)](MIT-LICENSE.txt)
 
 [![Master branch build](https://img.shields.io/azure-devops/build/linq2db/linq2db/8/master?label=build%20(master))](https://dev.azure.com/linq2db/linq2db/_build?definitionId=8&_a=summary) [![Latest build](https://img.shields.io/azure-devops/build/linq2db/linq2db/8?label=build%20(latest))](https://dev.azure.com/linq2db/linq2db/_build?definitionId=8&_a=summary)
 
-linq2db.LINQPad is a driver for [LINQPad 5 (.NET Framework 4.8)](http://www.linqpad.net) and [LINQPad 7 (.NET 6+)](http://www.linqpad.net).
+linq2db.LINQPad is a driver for [LINQPad 5 (.NET Framework 4.8)](http://www.linqpad.net) and [LINQPad 8 (.NET 8+)](http://www.linqpad.net).
 
 Following databases supported (by all LINQPad versions if other not specified):
 
-- **ClickHouse**: using Binary (LINQPad 7), HTTP and MySQL interfaces
-- **DB2** (LUW, z/OS): LINQPad 7 x64 and LINQPad 5 x86
+- **ClickHouse**: using Binary (LINQPad 8), HTTP and MySQL interfaces
+- **DB2** (LUW, z/OS): LINQPad 8 x64 and LINQPad 5)
+- **DB2 iSeries**: LINQPad 8 and LINQPad 5 (check release notes to see which version supports this database)
 - **Firebird**
-- **Informix**: LINQPad 7 x64 and LINQPad 5 x86
+- **Informix**: LINQPad 8 x64 and LINQPad 5
 - **Microsoft Access**: both OLE DB and ODBC drivers
 - **Microsoft SQL Server** 2005+ *(including **Microsoft SQL Azure**)*
 - **Microsoft SQL Server Compact (SQL CE)**
@@ -25,13 +26,13 @@ Following databases supported (by all LINQPad versions if other not specified):
 
 ## Download
 
-Releases are hosted on [Github](https://github.com/linq2db/linq2db.LINQPad/releases) and on [nuget.org](https://www.nuget.org/packages/linq2db.LINQPad) for LINQPad 7 driver.
+Releases are hosted on [Github](https://github.com/linq2db/linq2db.LINQPad/releases) and on [nuget.org](https://www.nuget.org/packages/linq2db.LINQPad) for LINQPad 8 driver.
 
 Latest build is hosted on [Azure Artifacts](https://dev.azure.com/linq2db/linq2db/_packaging?_a=package&feed=linq2db%40Local&package=linq2db.LINQPad&protocolType=NuGet). Feed [URL](https://pkgs.dev.azure.com/linq2db/linq2db/_packaging/linq2db/nuget/v3/index.json) ([how to use](https://docs.microsoft.com/en-us/nuget/consume-packages/install-use-packages-visual-studio#package-sources)).
 
 ## Installation
 
-### LINQPad 7 (NuGet)
+### LINQPad 8 (NuGet)
 
 - Click "Add connection" in LINQPad.
 - In the "Choose Data Context" dialog, press the "View more drivers..." button.
@@ -41,7 +42,7 @@ Latest build is hosted on [Azure Artifacts](https://dev.azure.com/linq2db/linq2d
 - In the "LINQ to DB connection" dialog, supply your connection information.
 - You're done.
 
-### LINQPad 7 (Manual)
+### LINQPad 8 (Manual)
 
 - Download latest **.lpx6** file from the link provided above.
 - Click "Add connection" in LINQPad.

--- a/Source/Configuration/ConnectionSettings.cs
+++ b/Source/Configuration/ConnectionSettings.cs
@@ -6,6 +6,11 @@ using System.Text.Json.Serialization;
 using System.Xml.Linq;
 using LINQPad.Extensibility.DataContext;
 using LinqToDB.LINQPad.Json;
+
+#if WITH_ISERIES
+using LinqToDB.DataProvider.DB2iSeries;
+#endif
+
 using PN = LinqToDB.ProviderName;
 
 namespace LinqToDB.LINQPad;
@@ -178,7 +183,7 @@ internal sealed class ConnectionSettings
 			{
 
 				PN.AccessOdbc         => PN.Access,
-				PN.MySqlConnector     => PN.MySql,
+				"MySqlConnector"      => PN.MySql,
 				PN.SybaseManaged      => PN.Sybase,
 				PN.SQLiteClassic      => PN.SQLite,
 				PN.InformixDB2        => PN.Informix,
@@ -192,7 +197,9 @@ internal sealed class ConnectionSettings
 					or PN.DB2LUW
 					or PN.DB2zOS
 					or PN.SqlServer
-					//or DB2iSeriesProviderName.DB2
+#if WITH_ISERIES
+					or DB2iSeriesProviderName.DB2
+#endif
 					or PN.SqlCe       => settings.Connection.Provider,
 				_                     => null
 			};
@@ -299,7 +306,7 @@ internal sealed class ConnectionSettings
 		else
 			cxInfo.DriverData.Element(name)?.Remove();
 	}
-	#endregion
+#endregion
 
 	public ConnectionOptions     Connection    { get; set; } = null!;
 	public SchemaOptions         Schema        { get; set; } = null!;

--- a/Source/Configuration/ConnectionSettings.cs
+++ b/Source/Configuration/ConnectionSettings.cs
@@ -214,7 +214,7 @@ internal sealed class ConnectionSettings
 			else
 			{
 				strValue = GetString(cxInfo, IncludeSchemas);
-				schemas = strValue == null ? null : new HashSet<string>(strValue.Split(_listSeparators, StringSplitOptions.RemoveEmptyEntries));
+				schemas = strValue == null ? null : [.. strValue.Split(_listSeparators, StringSplitOptions.RemoveEmptyEntries)];
 				if (schemas != null && schemas.Count > 0)
 					settings.Schema.IncludeSchemas = true;
 			}
@@ -228,7 +228,7 @@ internal sealed class ConnectionSettings
 			else
 			{
 				strValue = GetString(cxInfo, IncludeCatalogs);
-				catalogs = strValue == null ? null : new HashSet<string>(strValue.Split(_listSeparators, StringSplitOptions.RemoveEmptyEntries));
+				catalogs = strValue == null ? null : [.. strValue.Split(_listSeparators, StringSplitOptions.RemoveEmptyEntries)];
 				if (catalogs != null && catalogs.Count > 0)
 					settings.Schema.IncludeCatalogs = true;
 			}

--- a/Source/DatabaseProviders/DB2Provider.cs
+++ b/Source/DatabaseProviders/DB2Provider.cs
@@ -1,9 +1,13 @@
 ﻿using LinqToDB.Data;
 using System.Data.Common;
+
+#if WITH_ISERIES
 using LinqToDB.DataProvider.DB2iSeries;
+#endif
 
 #if NETFRAMEWORK
 using IBM.Data.DB2;
+using System.IO;
 #else
 using IBM.Data.Db2;
 #endif
@@ -17,14 +21,36 @@ internal sealed class DB2Provider : DatabaseProviderBase
 		new (ProviderName.DB2LUW       , "DB2 for Linux, UNIX and Windows (LUW)"),
 		// zOS provider not tested at all as we don't have access to database instance
 		new (ProviderName.DB2zOS       , "DB2 for z/OS"                         ),
+#if WITH_ISERIES
 		new (DB2iSeriesProviderName.DB2, "DB2 for i (iSeries)"                  ),
+#endif
 	];
 
 	public DB2Provider()
 		: base(ProviderName.DB2, "IBM DB2 (LUW, z/OS or iSeries)", _providers)
 	{
+#if WITH_ISERIES
 		DataConnection.AddProviderDetector(DB2iSeriesTools.ProviderDetector);
+#endif
 	}
+
+#if NETFRAMEWORK
+	internal static void LoadAssembly()
+	{
+		var assemblyPath = Path.Combine(Path.GetDirectoryName(typeof(DB2Provider).Assembly.Location), "IBM.Data.DB2.DLL_provider", IntPtr.Size == 4 ? "x86" : "x64", $"IBM.Data.DB2.dll");
+		if (!File.Exists(assemblyPath))
+			throw new LinqToDBLinqPadException($"Failed to locate IBM.Data.DB2 assembly at {assemblyPath}");
+
+		try
+		{
+			_ = Assembly.LoadFrom(assemblyPath);
+		}
+		catch (Exception ex)
+		{
+			throw new LinqToDBLinqPadException($"Failed to load IBM.Data.DB2 assembly: ({ex.GetType().Name}) {ex.Message}");
+		}
+	}
+#endif
 
 	public override void ClearAllPools(string providerName)
 	{
@@ -37,7 +63,9 @@ internal sealed class DB2Provider : DatabaseProviderBase
 		{
 			ProviderName.DB2LUW        => "SELECT MAX(TIME) FROM (SELECT MAX(ALTER_TIME) AS TIME FROM SYSCAT.ROUTINES UNION SELECT MAX(ALTER_TIME) AS TIME FROM SYSCAT.TABLES)",
 			ProviderName.DB2zOS        => "SELECT MAX(TIME) FROM (SELECT MAX(ALTEREDTS) AS TIME FROM SYSIBM.SYSROUTINES UNION SELECT MAX(ALTEREDTS) AS TIME FROM SYSIBM.SYSTABLES)",
+#if WITH_ISERIES
 			DB2iSeriesProviderName.DB2 => "SELECT MAX(TIME) FROM (SELECT MAX(LAST_ALTERED) AS TIME FROM QSYS2.SYSROUTINES UNION SELECT MAX(ROUTINE_CREATED) AS TIME FROM QSYS2.SYSROUTINES UNION SELECT MAX(LAST_ALTERED_TIMESTAMP) AS TIME FROM QSYS2.SYSTABLES)",
+#endif
 			_                          => throw new LinqToDBLinqPadException($"Unknown DB2 provider '{settings.Connection.Provider}'")
 		};
 

--- a/Source/DatabaseProviders/DatabaseProviders.cs
+++ b/Source/DatabaseProviders/DatabaseProviders.cs
@@ -25,12 +25,14 @@ internal static class DatabaseProviders
 		Register(providers, providersByName, new SqlCeProvider     ());
 #if !NETFRAMEWORK
 		if (IntPtr.Size == 8)
-			Register(providers, providersByName, new DB2Provider   ());
+		{
+			Register(providers, providersByName, new DB2Provider     ());
+			Register(providers, providersByName, new InformixProvider());
+		}
 #else
-		if (IntPtr.Size == 4)
-			Register(providers, providersByName, new DB2Provider   ());
-#endif
 		Register(providers, providersByName, new InformixProvider  ());
+		Register(providers, providersByName, new DB2Provider       ());
+#endif
 		Register(providers, providersByName, new SapHanaProvider   ());
 		Register(providers, providersByName, new OracleProvider    ());
 		Register(providers, providersByName, new SqlServerProvider ());
@@ -62,6 +64,11 @@ internal static class DatabaseProviders
 	public static void Init()
 	{
 		// trigger .cctors
+
+#if NETFRAMEWORK
+		// no harm in loading it here unconditionally instead of trying to detect all places where we really need it
+		DB2Provider.LoadAssembly();
+#endif
 	}
 
 	public static DbConnection CreateConnection(ConnectionSettings settings)

--- a/Source/DatabaseProviders/FirebirdProvider.cs
+++ b/Source/DatabaseProviders/FirebirdProvider.cs
@@ -7,7 +7,11 @@ internal sealed class FirebirdProvider : DatabaseProviderBase
 {
 	private static readonly IReadOnlyList<ProviderInfo> _providers =
 	[
-		new (ProviderName.Firebird, "Firebird"),
+		new (ProviderName.Firebird  , "Detect Dialect Automatically", true),
+		new (ProviderName.Firebird25, "Firebird 2.5"                      ),
+		new (ProviderName.Firebird3 , "Firebird 3"                        ),
+		new (ProviderName.Firebird4 , "Firebird 4"                        ),
+		new (ProviderName.Firebird5 , "Firebird 5"                        ),
 	];
 
 	public FirebirdProvider()

--- a/Source/DatabaseProviders/MySqlProvider.cs
+++ b/Source/DatabaseProviders/MySqlProvider.cs
@@ -8,7 +8,11 @@ internal sealed class MySqlProvider : DatabaseProviderBase
 {
 	private static readonly IReadOnlyList<ProviderInfo> _providers =
 	[
-		new (ProviderName.MySqlConnector, "MySql/MariaDB"),
+		new (ProviderName.MySql                  , "Detect Dialect Automatically", true),
+		new (ProviderName.MySql57MySqlConnector  , "MySql 5.7"),
+		new (ProviderName.MySql80MySqlConnector  , "MySql 8 & 9"),
+		new (ProviderName.MariaDB10MySqlConnector, "MariaDB"),
+		new ("MySqlConnector"                    , "removed since v6", IsHidden: true),
 	];
 
 	public MySqlProvider()

--- a/Source/DatabaseProviders/ProviderInfo.cs
+++ b/Source/DatabaseProviders/ProviderInfo.cs
@@ -6,4 +6,5 @@
 /// <param name="Name">Provider identifier (e.g. value from <see cref="ProviderName"/> class).</param>
 /// <param name="DisplayName">Provider display name in settings dialog.</param>
 /// <param name="IsDefault">When set, specified provider dialect will be selected automatically.</param>
-internal sealed record ProviderInfo(string Name, string DisplayName, bool IsDefault = false);
+/// <param name="IsHidden">When set, specified provider will not be shown in list of available dialects and used only to support old connections with provider names, existed in older releases.</param>
+internal sealed record ProviderInfo(string Name, string DisplayName, bool IsDefault = false, bool IsHidden = false);

--- a/Source/DatabaseProviders/SapHanaProvider.cs
+++ b/Source/DatabaseProviders/SapHanaProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System.Data.Common;
 using System.Data.Odbc;
 using LinqToDB.Data;
-using LinqToDB.DataProvider.SapHana;
 #if !NETFRAMEWORK
 using System.IO;
 #endif
@@ -26,13 +25,21 @@ internal sealed class SapHanaProvider : DatabaseProviderBase
 		return "https://tools.hana.ondemand.com/#hanatools";
 	}
 
+#if NETFRAMEWORK
+	private const string UnmanagedAssemblyName       = "Sap.Data.Hana.v4.5";
+#else
+	private const string UnmanagedAssemblyName       = "Sap.Data.Hana.Core.v2.1";
+#endif
+
 	public override void ClearAllPools(string providerName)
 	{
 		if (providerName == ProviderName.SapHanaOdbc)
 			OdbcConnection.ReleaseObjectPool();
 		else if (providerName == ProviderName.SapHanaNative)
 		{
-			var typeName = $"{SapHanaProviderAdapter.ClientNamespace}.HanaConnection, {SapHanaProviderAdapter.AssemblyName}";
+			// TODO: restore in next version
+			//var typeName = $"{SapHanaProviderAdapter.UnmanagedClientNamespace}.HanaConnection, {SapHanaProviderAdapter.UnmanagedAssemblyName}";
+			var typeName = $"Sap.Data.Hana.HanaConnection, {UnmanagedAssemblyName}";
 			Type.GetType(typeName, false)?.GetMethod("ClearAllPools", BindingFlags.Public | BindingFlags.Static)?.Invoke(null, null);
 		}
 	}
@@ -48,7 +55,9 @@ internal sealed class SapHanaProvider : DatabaseProviderBase
 		if (providerName == ProviderName.SapHanaOdbc)
 			return OdbcFactory.Instance;
 
-		var typeName = $"{SapHanaProviderAdapter.ClientNamespace}.HanaFactory, {SapHanaProviderAdapter.AssemblyName}";
+		// TODO: restore in next version
+		//var typeName = $"{SapHanaProviderAdapter.UnmanagedClientNamespace}.HanaFactory, {SapHanaProviderAdapter.UnmanagedAssemblyName}";
+		var typeName = $"Sap.Data.Hana.HanaFactory, {UnmanagedAssemblyName}";
 		return (DbProviderFactory)Type.GetType(typeName, false)?.GetField("Instance", BindingFlags.Public | BindingFlags.Static)?.GetValue(null)!;
 	}
 

--- a/Source/Drivers/PasswordManager.cs
+++ b/Source/Drivers/PasswordManager.cs
@@ -6,7 +6,9 @@ namespace LinqToDB.LINQPad
 {
 	internal static partial class PasswordManager
 	{
+#pragma warning disable SYSLIB1045 // Convert to 'GeneratedRegexAttribute'.
 		private static readonly Regex _tokenReplacer = new(@"\{pm:([^\}]+)\}", RegexOptions.Compiled);
+#pragma warning restore SYSLIB1045 // Convert to 'GeneratedRegexAttribute'.
 
 		[return: NotNullIfNotNull(nameof(value))]
 		public static string? ResolvePasswordManagerFields(string? value)

--- a/Source/Drivers/Scaffold/ModelProviderInterceptor.cs
+++ b/Source/Drivers/Scaffold/ModelProviderInterceptor.cs
@@ -554,12 +554,12 @@ internal sealed class ModelProviderInterceptor(ConnectionSettings settings, ISql
 	{
 		return sqlBuilder.BuildDataType(
 				new StringBuilder(),
-				new SqlDataType(new DbDataType(typeof(object),
+				new DbDataType(typeof(object),
 					dataType : dataType ?? DataType.Undefined,
 					dbType   : type.Name,
 					length   : type.Length,
 					precision: type.Precision,
-					scale    : type.Scale)))
+					scale    : type.Scale))
 			.ToString();
 	}
 

--- a/Source/UI/Model/DynamicConnectionModel.cs
+++ b/Source/UI/Model/DynamicConnectionModel.cs
@@ -26,15 +26,15 @@ internal sealed class DynamicConnectionModel : ConnectionModelBase, INotifyPrope
 		{
 			Providers.Clear();
 
-			foreach (var provider in db.Providers)
+			foreach (var provider in db.Providers.Where(p => !p.IsHidden))
 				Providers.Add(provider);
 
-			if (db.Providers.Count == 1)
-				Settings.Connection.Provider = db.Providers[0].Name;
+			if (Providers.Count == 1)
+				Settings.Connection.Provider = Providers[0].Name;
 		}
 
 		var old = ProviderVisibility;
-		ProviderVisibility = db?.Providers.Count > 1 && db?.AutomaticProviderSelection == false ? Visibility.Visible : Visibility.Collapsed;
+		ProviderVisibility = Providers.Count > 1 && db?.AutomaticProviderSelection == false ? Visibility.Visible : Visibility.Collapsed;
 
 		if (ProviderVisibility != old)
 			OnPropertyChanged(_providerVisibilityChangedEventArgs);

--- a/Source/linq2db.LINQPad.csproj
+++ b/Source/linq2db.LINQPad.csproj
@@ -13,7 +13,7 @@
 		<UseWPF>true</UseWPF>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
-		<LangVersion>preview</LangVersion>
+		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<!--https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/errors-warnings#warninglevel-->
 		<WarningLevel>9999</WarningLevel>
@@ -145,7 +145,7 @@
 		<Exec Command="$(ProjectDir)..\Build\Pack.cmd $(TargetDir) lpx6" />
 	</Target>
 
-	<Target Name="PostBuild2" AfterTargets="CopySQLiteInteropFiles;PostBuild1" Condition="'$(TargetFramework)' == 'net48'">
+	<Target Name="PostBuild2" AfterTargets="CopySQLiteInteropFiles" Condition="'$(TargetFramework)' == 'net48'">
 		<!--we are trying to deceive DB2 provider here, see UnsafeNativeMethods.DB2Interop.Init() method logic-->
 		<Delete Files="$(TargetDir)\IBM.Data.DB2.dll" />
 		<MakeDir Directories="$(TargetDir)\IBM.Data.DB2.DLL_provider" />

--- a/Source/linq2db.LINQPad.csproj
+++ b/Source/linq2db.LINQPad.csproj
@@ -145,7 +145,7 @@
 		<Exec Command="$(ProjectDir)..\Build\Pack.cmd $(TargetDir) lpx6" />
 	</Target>
 
-	<Target Name="PostBuild2" AfterTargets="CopySQLiteInteropFiles" Condition="'$(TargetFramework)' == 'net48'">
+	<Target Name="PostBuild2" AfterTargets="CopySQLiteInteropFiles;PostBuild1" Condition="'$(TargetFramework)' == 'net48'">
 		<!--we are trying to deceive DB2 provider here, see UnsafeNativeMethods.DB2Interop.Init() method logic-->
 		<Delete Files="$(TargetDir)\IBM.Data.DB2.dll" />
 		<MakeDir Directories="$(TargetDir)\IBM.Data.DB2.DLL_provider" />

--- a/Source/linq2db.LINQPad.csproj
+++ b/Source/linq2db.LINQPad.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
-		<TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
 		<RootNamespace>LinqToDB.LINQPad</RootNamespace>
 		<Company>linq2db</Company>
 		<Product>linq2db.LINQPad</Product>
 		<AssemblyTitle>$(Product)</AssemblyTitle>
-		<Version>5.4.2.0</Version>
+		<Version>6.0.0.0</Version>
 		<AssemblyVersion>$(Version)</AssemblyVersion>
 		<FileVersion>$(Version)</FileVersion>
-		<Copyright>Copyright © 2016-2024 Linq To DB Team</Copyright>
+		<Copyright>Copyright © 2016-2025 Linq To DB Team</Copyright>
 		<UseWPF>true</UseWPF>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
@@ -27,7 +27,11 @@
 		<!--required for SkipLocalsInit-->
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
+		<!--disable DB2 provider arch warnings-->
 		<MSBuildWarningsAsMessages>MSB3270</MSBuildWarningsAsMessages>
+
+		<!--don't forget to (un)comment reference in nuspec file!-->
+		<!--<DefineConstants>WITH_ISERIES;$(DefineConstants)</DefineConstants>-->
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -40,17 +44,14 @@
 		<ReportAnalyzer>false</ReportAnalyzer>
 		<!--workaround for https://github.com/dotnet/roslyn/issues/41640, but also required for xml-doc validation -->
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	</PropertyGroup>
 
-	<PropertyGroup Label="NETFX DLL HELL workaround" Condition=" '$(TargetFramework)' == 'net48' ">
-		<MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<Using Include="System.Reflection" />
 
-		<PackageReference Include="linq2db" />
 		<PackageReference Include="linq2db.Tools" />
+		<PackageReference Include="linq2db.Scaffold" />
 		<PackageReference Include="LINQPad.Reference" />
 		<PackageReference Include="PolySharp" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
@@ -61,7 +62,7 @@
 		<PackageReference Include="Microsoft.Data.SqlClient" />
 		<PackageReference Include="Npgsql" />
 		<PackageReference Include="ClickHouse.Client" />
-		<PackageReference Include="linq2db4iSeries" />
+		<PackageReference Include="linq2db4iSeries" Condition="$(DefineConstants.Contains('WITH_ISERIES'))" />
 		<PackageReference Include="Microsoft.SqlServer.Types" />
 
 		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" />
@@ -75,19 +76,22 @@
 		<Reference Include="Microsoft.CSharp" />
 		<Reference Include="System.Configuration" />
 
-		<PackageReference Include="System.ValueTuple" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" />
 		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
 		<PackageReference Include="System.Memory" />
 		<PackageReference Include="System.Buffers" />
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" NoWarn="NU1605" />
-		<PackageReference Include="System.Text.Json" NoWarn="NU1605;NU1903" />
+		<PackageReference Include="System.Text.Json" />
 		<PackageReference Include="Oracle.ManagedDataAccess" />
-		<PackageReference Include="IBM.Data.DB.Provider" GeneratePathProperty="true" />
 
-		<Reference Include="IBM.Data.DB2">
-			<HintPath>$(PkgIBM_Data_DB_Provider)\build\net451\x86\IBM.Data.DB2.dll</HintPath>
+		<!--PackageReference + Reference beelongs to same nuget-->
+		<PackageReference Include="IBM.Data.DB.Provider" GeneratePathProperty="true" />
+		<Reference Include="IBM.Data.DB2" Condition=" $(PlatformTarget) != 'x86' ">
+			<HintPath>$(PkgIBM_Data_DB_Provider)\build\net451\x64\IBM.Data.DB2.dll</HintPath>
 		</Reference>
+		<Reference Include="IBM.Data.DB2" Condition=" $(PlatformTarget) == 'x86' ">
+			<HintPath>$(PkgIBM_Data_DB_Provider)\build\net451\x86\IBM.Data.DB2.DLL</HintPath>
+		</Reference>
+
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
@@ -142,6 +146,12 @@
 	</Target>
 
 	<Target Name="PostBuild2" AfterTargets="CopySQLiteInteropFiles" Condition="'$(TargetFramework)' == 'net48'">
+		<!--we are trying to deceive DB2 provider here, see UnsafeNativeMethods.DB2Interop.Init() method logic-->
+		<Delete Files="$(TargetDir)\IBM.Data.DB2.dll" />
+		<MakeDir Directories="$(TargetDir)\IBM.Data.DB2.DLL_provider" />
+		<Copy SourceFiles="$(PkgIBM_Data_DB_Provider)\build\net451\x64\IBM.Data.DB2.dll" DestinationFiles="$(TargetDir)\IBM.Data.DB2.DLL_provider\x64\IBM.Data.DB2.dll" />
+		<Copy SourceFiles="$(PkgIBM_Data_DB_Provider)\build\net451\x86\IBM.Data.DB2.dll" DestinationFiles="$(TargetDir)\IBM.Data.DB2.DLL_provider\x86\IBM.Data.DB2.dll" />
+
 		<Exec Command="$(ProjectDir)..\Build\Pack.cmd $(TargetDir) lpx" />
 	</Target>
 

--- a/linq2db.LINQPad.sln
+++ b/linq2db.LINQPad.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".root", ".root", "{B05A0C36
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		MIT-LICENSE.txt = MIT-LICENSE.txt
 		nuget.config = nuget.config
@@ -26,8 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{A26F7937
 		Build\icon64.png = Build\icon64.png
 		Build\linq2db.LINQPad.nuspec = Build\linq2db.LINQPad.nuspec
 		Build\nuget-vars.yml = Build\nuget-vars.yml
-		Build\README.md = Build\README.md
 		Build\Pack.cmd = Build\Pack.cmd
+		Build\README.md = Build\README.md
 		Build\SetVersion.ps1 = Build\SetVersion.ps1
 	EndProjectSection
 EndProject

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,21 @@
+Latest version with DB2 iSeries support: 5.4.2
+
+# Release 6.0.0-preview.3
+
+Changes:
+
+- update to linq2db 6.0.0-preview.3
+- update dependencies
+- bump lowest supported .NET runtime version to `net8.0` from `net6.0`
+- supported LinqPad versions for this release are 5 (for .NET Framework) and 8+ (for .NET)
+- added .NET 9 support
+- added support for DB2 provider for LinqPad 5 x64
+- following providers now allow you to select SQL dialect in settings: MySQL/MariaDB, Firebird
+- hide Informix provider from x86 version of LinqPad 8 (there is no x86 driver for .NET available)
+- [#125](https://github.com/linq2db/linq2db.LINQPad/issues/125): fix exception thrown for Access database without tables or procedures
+
+DB2 iSeries provider disabled in this version (use 5.4.2 if you need this provider), because it doesn't support Linq To DB 6 yet.
+
 # Release 5.4.2
 
 Changes:


### PR DESCRIPTION
from release notes.md:

---

# Release 6.0.0-preview.3

Changes:

- update to linq2db 6.0.0-preview.3
- update dependencies
- bump lowest supported .NET runtime version to `net8.0` from `net6.0`
- supported LinqPad versions for this release are 5 (for .NET Framework) and 8+ (for .NET)
- added .NET 9 support
- added support for DB2 provider for LinqPad 5 x64
- following providers now allow you to select SQL dialect in settings: MySQL/MariaDB, Firebird
- hide Informix provider from x86 version of LinqPad 8 (there is no x86 driver for .NET available)
- [#125](https://github.com/linq2db/linq2db.LINQPad/issues/125): fix exception thrown for Access database without tables or procedures